### PR TITLE
#2: refactor to allow bloch-lang comments to start with '//'

### DIFF
--- a/src/bloch/lexer/lexer.cpp
+++ b/src/bloch/lexer/lexer.cpp
@@ -27,6 +27,10 @@ namespace bloch {
         return m_position < m_source.length() ? m_source[m_position] : '\0';
     }
 
+    char Lexer::peekNext() const {
+        return (m_position + 1) < m_source.length() ? m_source[m_position + 1] : '\0';
+    }
+
     char Lexer::advance() {
         char c = m_source[m_position++];
         m_column++;
@@ -53,7 +57,9 @@ namespace bloch {
                     continue;
                 }
                 advance();
-            } else if (c == '#') {
+            } else if (c == '/' && peekNext() == '/') {
+                advance();
+                advance();
                 skipComment();
             } else {
                 break;

--- a/src/bloch/lexer/lexer.hpp
+++ b/src/bloch/lexer/lexer.hpp
@@ -18,6 +18,7 @@ namespace bloch {
         int m_column;
 
         char peek() const;
+        char peekNext() const;
         char advance();
 
         bool match(char expected);

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -103,7 +103,7 @@ TEST(LexerTest, LineAndColumnTracking) {
 }
 
 TEST(LexerTest, SkipsComments) {
-    Lexer lexer("int x # comment\ny");
+    Lexer lexer("int x // comment\ny");
     auto tokens = lexer.tokenize();
 
     ASSERT_GE(tokens.size(), 4);


### PR DESCRIPTION
Comments in bloch-lang now begin with // rather than # 

Closes #2 