### PR TITLE
#22: implement else statements

### DIFF
--- a/src/bloch/lexer/lexer.cpp
+++ b/src/bloch/lexer/lexer.cpp
@@ -74,7 +74,7 @@ namespace bloch {
     }
 
     void Lexer::reportError(const std::string& msg) {
-        throw BlochRuntimeError("[Bloch Lexer Error]", m_line, m_column, msg);
+        throw BlochRuntimeError("Bloch Lexer Error", m_line, m_column, msg);
     }
 
     Token Lexer::makeToken(TokenType type, const std::string& value) {
@@ -181,6 +181,7 @@ namespace bloch {
             {"import", TokenType::Import},
             {"return", TokenType::Return},
             {"if", TokenType::If},
+            {"else", TokenType::Else},
             {"for", TokenType::For},
             {"class", TokenType::Class},
             {"measure", TokenType::Measure},

--- a/src/bloch/lexer/token.hpp
+++ b/src/bloch/lexer/token.hpp
@@ -24,6 +24,7 @@ namespace bloch {
         Import,
         Return,
         If,
+        Else,
         For,
         Class,
         Measure,

--- a/src/bloch/parser/parser.hpp
+++ b/src/bloch/parser/parser.hpp
@@ -36,7 +36,6 @@ namespace bloch {
         std::unique_ptr<ImportStatement> parseImport();
         std::unique_ptr<FunctionDeclaration> parseFunction();
         std::unique_ptr<ClassDeclaration> parseClass();
-        std::unique_ptr<Statement> parseTopLevelStatement();
 
         // Declarations
         std::unique_ptr<VariableDeclaration> parseVariableDeclaration(bool isFinal);

--- a/src/bloch/semantics/semantic_analyser.cpp
+++ b/src/bloch/semantics/semantic_analyser.cpp
@@ -12,7 +12,7 @@ namespace bloch {
 
     void SemanticAnalyser::visit(VariableDeclaration& node) {
         if (isDeclared(node.name)) {
-            throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                     "Variable '" + node.name + "' redeclared");
         }
         declare(node.name, node.isFinal);
@@ -34,11 +34,11 @@ namespace bloch {
     void SemanticAnalyser::visit(ReturnStatement& node) {
         bool isVoid = dynamic_cast<VoidType*>(m_currentReturnType) != nullptr;
         if (node.value && isVoid) {
-            throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                     "Void function cannot return a value");
         }
         if (!node.value && !isVoid) {
-            throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                     "Non-void function must return a value");
         }
         if (node.value)
@@ -84,11 +84,11 @@ namespace bloch {
 
     void SemanticAnalyser::visit(AssignmentStatement& node) {
         if (!isDeclared(node.name)) {
-            throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                     "Variable '" + node.name + "' not declared");
         }
         if (isFinal(node.name)) {
-            throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                     "Cannot assign to final variable '" + node.name + "'");
         }
         if (node.value)
@@ -111,7 +111,7 @@ namespace bloch {
 
     void SemanticAnalyser::visit(VariableExpression& node) {
         if (!isDeclared(node.name)) {
-            throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                     "Variable '" + node.name + "' not declared");
         }
     }
@@ -141,11 +141,11 @@ namespace bloch {
 
     void SemanticAnalyser::visit(AssignmentExpression& node) {
         if (!isDeclared(node.name)) {
-            throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                     "Variable '" + node.name + "' not declared");
         }
         if (isFinal(node.name)) {
-            throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                     "Cannot assign to final variable '" + node.name + "'");
         }
         if (node.value)
@@ -184,7 +184,7 @@ namespace bloch {
                     valid = true;
             }
             if (!valid) {
-                throw BlochRuntimeError("[Bloch Semantic Error]", node.line, node.column,
+                throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
                                         "@quantum functions must return 'bit' or 'void'");
             }
         }
@@ -194,7 +194,7 @@ namespace bloch {
         beginScope();
         for (auto& param : node.params) {
             if (isDeclared(param->name)) {
-                throw BlochRuntimeError("[Bloch Semantic Error]", param->line, param->column,
+                throw BlochRuntimeError("Bloch Semantic Error", param->line, param->column,
                                         "Parameter '" + param->name + "' redeclared");
             }
             declare(param->name, false);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -221,3 +221,25 @@ TEST(ParserTest, ExpressionPrecedence) {
     ASSERT_NE(mul, nullptr);
     EXPECT_EQ(mul->op, "*");
 }
+
+TEST(ParserTest, ParseIfElse) {
+    const char* src = "if (1) { return 1; } else { return 0; }";
+    Lexer lexer(src);
+    auto tokens = lexer.tokenize();
+    Parser parser(tokens);
+    auto program = parser.parse();
+
+    ASSERT_EQ(program->statements.size(), 1u);
+    auto* ifStmt = dynamic_cast<IfStatement*>(program->statements[0].get());
+    ASSERT_NE(ifStmt, nullptr);
+    ASSERT_NE(ifStmt->thenBranch, nullptr);
+    ASSERT_NE(ifStmt->elseBranch, nullptr);
+
+    auto* thenBlock = dynamic_cast<BlockStatement*>(ifStmt->thenBranch.get());
+    ASSERT_NE(thenBlock, nullptr);
+    ASSERT_EQ(thenBlock->statements.size(), 1u);
+
+    auto* elseBlock = dynamic_cast<BlockStatement*>(ifStmt->elseBranch.get());
+    ASSERT_NE(elseBlock, nullptr);
+    ASSERT_EQ(elseBlock->statements.size(), 1u);
+}

--- a/tests/test_semantics.cpp
+++ b/tests/test_semantics.cpp
@@ -82,8 +82,22 @@ TEST(SemanticTest, QuantumReturnTypeBitAllowed) {
     EXPECT_NO_THROW(analyser.analyse(*program));
 }
 
-TEST(SemanticTest, QuantumReturnTypeInvalid) {
+TEST(SemanticTest, QuantumReturnTypeInvalidInt) {
     const char* src = "@quantum function q() -> int { return 0; }";
+    auto program = parseProgram(src);
+    SemanticAnalyser analyser;
+    EXPECT_THROW(analyser.analyse(*program), BlochRuntimeError);
+}
+
+TEST(SemanticTest, QuantumReturnTypeInvalidString) {
+    const char* src = "@quantum function q() -> string { return \"hello\"; }";
+    auto program = parseProgram(src);
+    SemanticAnalyser analyser;
+    EXPECT_THROW(analyser.analyse(*program), BlochRuntimeError);
+}
+
+TEST(SemanticTest, QuantumReturnTypeInvalidChar) {
+    const char* src = "@quantum function q() -> char { return \'c\'; }";
     auto program = parseProgram(src);
     SemanticAnalyser analyser;
     EXPECT_THROW(analyser.analyse(*program), BlochRuntimeError);


### PR DESCRIPTION
Implements else statement and cleans up parser (deprecates `parseTopLevelStatement()`, redirects to `parseStatement()`)

Closes #22 