### PR TITLE
#23: add  keyword to lexer

### DIFF
--- a/src/bloch/lexer/lexer.cpp
+++ b/src/bloch/lexer/lexer.cpp
@@ -174,6 +174,7 @@ namespace bloch {
             {"char", TokenType::Char},
             {"qubit", TokenType::Qubit},
             {"bit", TokenType::Bit},
+            {"logical", TokenType::Logical},
 
             // Keywords
             {"void", TokenType::Void},

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -45,6 +45,15 @@ TEST(LexerTest, KeywordDetection) {
     EXPECT_EQ(tokens[2].type, TokenType::Return);
 }
 
+TEST(LexerTest, LogicalKeyword) {
+    Lexer lexer("logical");
+    auto tokens = lexer.tokenize();
+
+    ASSERT_EQ(tokens.size(), 2);
+    EXPECT_EQ(tokens[0].type, TokenType::Logical);
+    EXPECT_EQ(tokens[0].value, "logical");
+}
+
 TEST(LexerTest, Operators) {
     Lexer lexer("-> + - * / ;");
     auto tokens = lexer.tokenize();


### PR DESCRIPTION
Add keyword `logical` to lexer primitive list. 

Closes #23 