### PR TITLE
#24: remove old `version` starter code

### DIFF
--- a/src/bloch/version/version.cpp
+++ b/src/bloch/version/version.cpp
@@ -1,5 +1,0 @@
-#include "version.hpp"
-
-namespace bloch {
-    void dummy() {}
-}

--- a/src/bloch/version/version.hpp
+++ b/src/bloch/version/version.hpp
@@ -1,5 +1,0 @@
-#pragma once
-
-namespace bloch {
-    constexpr const char* version = "0.1.0";
-}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,8 @@
 #include <iostream>
 #include "bloch/lexer/lexer.hpp"
-#include "bloch/version/version.hpp"
 
 int main() {
-    std::cout << "Bloch Language Compiler v" << bloch::version << std::endl;
+    std::cout << "Bloch: A General Purpose Quantum Programming Language";
 
     bloch::Lexer lexer("");
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,6 @@ FetchContent_MakeAvailable(googletest)
 enable_testing()
 
 add_executable(bloch_tests
-    test_version.cpp
     test_lexer.cpp
     test_ast.cpp
     test_parser.cpp

--- a/tests/test_version.cpp
+++ b/tests/test_version.cpp
@@ -1,4 +1,0 @@
-#include <gtest/gtest.h>
-#include "bloch/version/version.hpp"
-
-TEST(VersionTest, HasCorrectVersion) { EXPECT_STREQ(bloch::version, "0.1.0"); }


### PR DESCRIPTION
Remove old starter code - no longer needed 

Closes #24 