### PR TITLE
Create docs for compiler architecture and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Bloch is designed to provide developers with intuitive syntax, robust tooling, a
 > ⚠ **Note:** docs are still under construction.
 
 See `/docs` for 
-- Language specification
-- Grammar
+- [Grammar](docs/grammar.md)
 - Standard library
-- How the compiler works
+- [How the compiler works](docs/compiler.md)
 
 ## 🚀 Usage
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,0 +1,41 @@
+# Bloch Compiler Overview
+
+Bloch's compiler transforms source files written in the Bloch language into an intermediate representation suitable for execution or further translation.
+
+## Architecture
+
+1. **Lexer**  
+   Converts raw source text into a stream of tokens. The lexer performs whitespace and comment skipping, recognises literals and keywords, and attaches line/column information for diagnostics.
+2. **Parser**  
+   Consumes the token stream to build an Abstract Syntax Tree (AST). Parsing follows the grammar defined in `grammar.md` and produces nodes such as `Program`, `FunctionDeclaration`, and `Expression` classes located in `src/bloch/ast`.
+3. **Semantic Analysis**  
+   Traverses the AST to check for correctness. The analyser validates variable declarations, scope rules, function return types and other language constraints. Errors are reported using `BlochRuntimeError` with line and column details.
+4. **Code Generation** *(planned)*  
+   The current repository does not yet implement backend code generation. The intended target is an OpenQASM compatible representation for running on real or simulated quantum hardware.
+
+## Usage
+
+Building the compiler requires a C++17 toolchain and CMake 3.15 or later:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+After building, run the compiler with a Bloch source file:
+
+```bash
+./bloch <file.bloch>
+```
+
+The compiler will tokenize, parse and analyse the input. When backend code generation is implemented, it will output the resulting program representation.
+
+## Key Files
+
+- `src/bloch/lexer/` – lexical analysis implementation
+- `src/bloch/parser/` – recursive descent parser
+- `src/bloch/ast/` – AST node definitions
+- `src/bloch/semantics/` – semantic analyser
+
+Refer to the source directories for more details on each stage.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -1,0 +1,67 @@
+# Bloch Grammar (EBNF)
+
+```
+program        = { import | function | class | statement } ;
+
+import         = "import" identifier ";" ;
+
+class          = "class" identifier "{" { classSection } "}" ;
+classSection   = membersSection | methodsSection ;
+membersSection = "@members" "(" ("\"public\"" | "\"private\"") ")" ":" { variableDeclaration } ;
+methodsSection = "@methods" ":" { function } ;
+
+function       = { annotation } "function" [ "*" ] identifier
+                  "(" [ parameterList ] ")" "->" type block ;
+
+annotation     = "@" ( "quantum" | "adjoint" | stateAnnotation ) ;
+stateAnnotation= "state" "(" ( charLiteral | stringLiteral ) ")" ;
+
+parameterList  = parameter { "," parameter } ;
+parameter      = type identifier ;
+
+block          = "{" { statement } "}" ;
+
+statement      = block
+               | [ "final" ] variableDeclaration
+               | "return" [ expression ] ";"
+               | "if" "(" expression ")" block [ "else" block ]
+               | "for" "(" [ forInit ] expression ";" expression ")" block
+               | "echo" "(" expression ")" ";"
+               | "reset" expression ";"
+               | "measure" expression ";"
+               | assignment
+               | expressionStatement ;
+
+forInit        = ( "final" )? variableDeclaration | expressionStatement ;
+
+variableDeclaration = annotations? type identifier [ "=" expression ] ";" ;
+annotations    = annotation { annotation } ;
+
+assignment     = identifier "=" expression ";" ;
+expressionStatement = expression ";" ;
+
+expression            = assignmentExpression ;
+assignmentExpression  = comparison [ "=" assignmentExpression ] ;
+comparison            = additive { (">" | "<" | ">=" | "<=") additive } ;
+additive              = multiplicative { ("+" | "-") multiplicative } ;
+multiplicative        = unary { ("*" | "/" | "%") unary } ;
+unary                 = constructorCall | "-" unary | call ;
+constructorCall       = "*" identifier "(" [ argumentList ] ")" ;
+call                  = primary { ("." identifier) | "(" [ argumentList ] ")" } ;
+argumentList          = expression { "," expression } ;
+primary               = literal
+                      | "measure" expression
+                      | identifier
+                      | "(" expression ")" ;
+
+literal               = integerLiteral
+                      | floatLiteral
+                      | stringLiteral
+                      | charLiteral ;
+
+type                  = primitiveType [ "[" "]" ]
+                      | identifier ;
+primitiveType         = "void" | "int" | "float" | "char" | "string"
+                      | "bit" | "qubit" | logicalType ;
+logicalType           = "logical" "<" identifier ">" ;
+```


### PR DESCRIPTION
Added `grammar.md` and `compiler.md` to explain the compiler architecture and the Bloch language grammar. 

Closes #21 