### PR TITLE
#21: use std::move to prevent dangling references in the Parser

### DIFF
--- a/src/bloch/parser/parser.cpp
+++ b/src/bloch/parser/parser.cpp
@@ -5,7 +5,7 @@
 #include "../error/bloch_runtime_error.hpp"
 
 namespace bloch {
-    Parser::Parser(const std::vector<Token>& tokens) : m_tokens(tokens), m_current(0) {}
+    Parser::Parser(std::vector<Token> tokens) : m_tokens(std::move(tokens)), m_current(0) {}
 
     // Token manipulation
     const Token& Parser::peek() const {
@@ -743,7 +743,6 @@ namespace bloch {
             args.push_back(parseExpression());
         } while (match(TokenType::Comma));
 
-        expect(TokenType::RParen, "Expected ')' after argument list");
         return args;
     }
 }

--- a/src/bloch/parser/parser.hpp
+++ b/src/bloch/parser/parser.hpp
@@ -10,11 +10,11 @@
 namespace bloch {
     class Parser {
        public:
-        explicit Parser(const std::vector<Token>& tokens);
+        explicit Parser(std::vector<Token> tokens);
         [[nodiscard]] std::unique_ptr<Program> parse();
 
        private:
-        const std::vector<Token>& m_tokens;
+        std::vector<Token> m_tokens;
         size_t m_current;
 
         // Token manipulation

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -8,7 +8,7 @@ using namespace bloch;
 TEST(ParserTest, ParseImport) {
     Lexer lexer("import math;");
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->imports.size(), 1u);
@@ -18,7 +18,7 @@ TEST(ParserTest, ParseImport) {
 TEST(ParserTest, ParseVariableDeclaration) {
     Lexer lexer("int x;");
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->statements.size(), 1u);
@@ -35,7 +35,7 @@ TEST(ParserTest, ParseVariableDeclaration) {
 TEST(ParserTest, ParseInitialisedVariableDeclaration) {
     Lexer lexer("int x = 10;");
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->statements.size(), 1u);
@@ -56,7 +56,7 @@ TEST(ParserTest, ParseInitialisedVariableDeclaration) {
 TEST(ParserTest, ParseFinalVariableDeclaration) {
     Lexer lexer("final int x;");
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->statements.size(), 1u);
@@ -74,7 +74,7 @@ TEST(ParserTest, ParseFinalVariableDeclaration) {
 TEST(ParserTest, ParseInitialisedFinalVariableDeclaration) {
     Lexer lexer("final int x = 10;");
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->statements.size(), 1u);
@@ -97,7 +97,7 @@ TEST(ParserTest, ParseQubitWithStateAnnotation) {
     const char* src = "@state(\"+\") qubit q;";
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->statements.size(), 1u);
@@ -118,7 +118,7 @@ TEST(ParserTest, ParseClassicalFunction) {
     const char* src = "function add(int a, int b) -> int { return a + b; }";
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->functions.size(), 1u);
@@ -147,7 +147,7 @@ TEST(ParserTest, ParseQuantumFunction) {
     const char* src = "@quantum function q() -> void { }";
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->functions.size(), 1u);
@@ -163,7 +163,7 @@ TEST(ParserTest, ParseClass) {
         "class Foo { @members(\"public\"): int x; @methods: function bar() -> int { return 5; } }";
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->classes.size(), 1u);
@@ -185,7 +185,7 @@ TEST(ParserTest, ParseConstructorFunction) {
     const char* src = "function *Foo() -> void { }";
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->functions.size(), 1u);
@@ -205,7 +205,7 @@ TEST(ParserTest, ExpressionPrecedence) {
     const char* src = "int x = 1 + 2 * 3;";
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->statements.size(), 1u);
@@ -226,7 +226,7 @@ TEST(ParserTest, ParseIfElse) {
     const char* src = "if (1) { return 1; } else { return 0; }";
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     auto program = parser.parse();
 
     ASSERT_EQ(program->statements.size(), 1u);

--- a/tests/test_semantics.cpp
+++ b/tests/test_semantics.cpp
@@ -9,7 +9,7 @@ using namespace bloch;
 static std::unique_ptr<Program> parseProgram(const char* src) {
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
-    Parser parser(tokens);
+    Parser parser(std::move(tokens));
     return parser.parse();
 }
 


### PR DESCRIPTION
Pass in a new `std::vector<Token>` object to the Parser rather than a `const std::vector<Token>&` reference and use `std::move` to move the contents, this will prevent dangling references to the Token list.

Closes #31 