### PR TITLE
#74: removed @state annotation as not supported by compile target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Bloch langugae are documented here
 This project follows [Semantic Versioning](https://semver.org/) and the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. 
 
 ## [Unreleased]
+### Removed
+- #74: removed `@state` annotations as they are not supported by OpenQASM
 ### Changed
 - #77: simplifed Parser by making better use of the `expect` function
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bloch — A High-Level Quantum Programming Language
+# Bloch — A Modern Quantum Programming Language
 **Bloch** is a strongly typed, compiled quantum programming language designed for hybrid classical-quantum computation. It combines classical control with OpenQASM-compatible quantum semantics, enabling intuitive yet powerful quantum algorithm development.
 
 Bloch is designed to provide developers with intuitive syntax, robust tooling, and seamless compilation to OpenQASM for execution on real or simulated quantum hardware.

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -13,8 +13,7 @@ methodsSection = "@methods" ":" { function } ;
 function       = { annotation } "function" [ "*" ] identifier
                   "(" [ parameterList ] ")" "->" type block ;
 
-annotation     = "@" ( "quantum" | "adjoint" | stateAnnotation ) ;
-stateAnnotation= "state" "(" ( charLiteral | stringLiteral ) ")" ;
+annotation     = "@" ( "quantum" | "adjoint" ) ;
 
 parameterList  = parameter { "," parameter } ;
 parameter      = type identifier ;

--- a/src/bloch/lexer/lexer.cpp
+++ b/src/bloch/lexer/lexer.cpp
@@ -201,7 +201,6 @@ namespace bloch {
             // Annotation Values
             {"quantum", TokenType::Quantum},
             {"adjoint", TokenType::Adjoint},
-            {"state", TokenType::State},
             {"members", TokenType::Members},
             {"methods", TokenType::Methods},
 

--- a/src/bloch/lexer/token.hpp
+++ b/src/bloch/lexer/token.hpp
@@ -36,7 +36,6 @@ namespace bloch {
         // Annotations
         At,
         Quantum,
-        State,
         Adjoint,
         Members,
         Methods,

--- a/src/bloch/parser/parser.cpp
+++ b/src/bloch/parser/parser.cpp
@@ -256,27 +256,17 @@ namespace bloch {
         return var;
     }
 
-    // @quantum, @adjoint, @state
+    // @quantum, @adjoint
     std::unique_ptr<AnnotationNode> Parser::parseAnnotation() {
         (void)expect(TokenType::At, "Expected '@' to begin annotation");
 
-        if (!check(TokenType::Quantum) && !check(TokenType::Adjoint) && !check(TokenType::State)) {
+        if (!check(TokenType::Quantum) && !check(TokenType::Adjoint)) {
             reportError("Unknown annotation");
         }
 
         auto nameToken = advance();
         auto annotation = std::make_unique<AnnotationNode>();
         annotation->name = nameToken.value;
-
-        if (annotation->name == "state") {
-            (void)expect(TokenType::LParen, "Expected '(' after @state");
-            if (!check(TokenType::CharLiteral) && !check(TokenType::StringLiteral)) {
-                reportError("Expected character or string inside @state(...)");
-            }
-            annotation->value = advance().value;
-            (void)expect(TokenType::RParen, "Expected ')' after @state argument");
-        }
-
         return annotation;
     }
 

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -87,7 +87,7 @@ TEST(LexerTest, CharLiteral) {
 TEST(LexerTest, UnterminatedStringThrows) {
     Lexer lexer("\"hello");
 
-    EXPECT_THROW({ lexer.tokenize(); }, BlochRuntimeError);
+    EXPECT_THROW({ (void)lexer.tokenize(); }, BlochRuntimeError);
 }
 
 TEST(LexerTest, UnterminatedCharThrows) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -94,25 +94,12 @@ TEST(ParserTest, ParseInitialisedFinalVariableDeclaration) {
     EXPECT_EQ(lit->value, "10");
 }
 
-TEST(ParserTest, ParseQubitWithStateAnnotation) {
+TEST(ParserTest, StateAnnotationIsRejected) {
     const char* src = "@state(\"+\") qubit q;";
     Lexer lexer(src);
     auto tokens = lexer.tokenize();
     Parser parser(std::move(tokens));
-    auto program = parser.parse();
-
-    ASSERT_EQ(program->statements.size(), 1u);
-
-    auto* var = dynamic_cast<VariableDeclaration*>(program->statements[0].get());
-    ASSERT_NE(var, nullptr);
-    ASSERT_EQ(var->annotations.size(), 1u);
-    EXPECT_EQ(var->annotations[0]->name, "state");
-    EXPECT_EQ(var->annotations[0]->value, "\"+\"");
-
-    auto* type = dynamic_cast<PrimitiveType*>(var->varType.get());
-    ASSERT_NE(type, nullptr);
-    EXPECT_EQ(type->name, "qubit");
-    EXPECT_EQ(var->name, "q");
+    EXPECT_THROW(parser.parse(), BlochRuntimeError);
 }
 
 TEST(ParserTest, ParseClassicalFunction) {


### PR DESCRIPTION
Setting an initial state other than |0> is not supported in OpenQASM 2.0 or 3.0 and so it is redundant as a Bloch feature, therefore removing. 

Closes #74 