### PR TITLE
#87: fix bug where echo was outputting to the console twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ cmake_install.cmake
 
 # Generated files
 compile_commands.json
+
+# Examples folder
+examples/*.cpp
+examples/*.qasm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project follows [Semantic Versioning](https://semver.org/) and the [Keep a 
 - #51: ensured all boolean fields in AST nodes are initialised
 - #77: addressed no return type warnings in lexer and parser
 - #79: fix division by zero bug in `RuntimeEvaluator::eval` to throw a `RuntimeError` instead of crashing when divisor is zero
+- #87: fix bug where `echo()` was printing to the console twice
 
 ### Removed  
 - #24: remove old `version` starter code

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,13 +64,6 @@ int main(int argc, char** argv) {
             std::cout << cpp;
             return 0;
         }
-        std::string out = base + ".out";
-        std::string cmd = "g++ -std=c++17 " + base + ".cpp -o " + out;
-        if (std::system(cmd.c_str()) != 0) {
-            std::cerr << "Failed to compile generated C++\n";
-            return 1;
-        }
-        std::system(("./" + out).c_str());
     } catch (const std::exception& ex) {
         std::cerr << ex.what() << std::endl;
         return 1;


### PR DESCRIPTION
Bloch code was being interpreted and then the compiled C++ was being run, resulting in the console outputs being output twice

closes #87 