### PR TITLE
#78: fix bug where loops were overwriting previous measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project follows [Semantic Versioning](https://semver.org/) and the [Keep a 
 - #77: addressed no return type warnings in lexer and parser
 - #79: fix division by zero bug in `RuntimeEvaluator::eval` to throw a `RuntimeError` instead of crashing when divisor is zero
 - #87: fix bug where `echo()` was printing to the console twice
+- #78: fix bug where looped measurements of the same qubit were overwriting old measurements
 
 ### Removed  
 - #24: remove old `version` starter code

--- a/src/bloch/codegen/cpp_generator.cpp
+++ b/src/bloch/codegen/cpp_generator.cpp
@@ -60,14 +60,14 @@ namespace bloch {
             }
             oss << ")";
             auto it = m_measure.find(e);
-            if (it != m_measure.end()) {
-                return it->second ? "true" : "false";
+            if (it != m_measure.end() && !it->second.empty()) {
+                return it->second.back() ? "true" : "false";
             }
             return oss.str();
         } else if (auto meas = dynamic_cast<MeasureExpression*>(e)) {
             auto it = m_measure.find(e);
-            if (it != m_measure.end())
-                return it->second ? "true" : "false";
+            if (it != m_measure.end() && !it->second.empty())
+                return it->second.back() ? "true" : "false";
             return "false";
         } else if (auto assign = dynamic_cast<AssignmentExpression*>(e)) {
             return assign->name + " = " + genExpr(assign->value.get());

--- a/src/bloch/codegen/cpp_generator.hpp
+++ b/src/bloch/codegen/cpp_generator.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include "../ast/ast.hpp"
 #include "../semantics/built_ins.hpp"
 
@@ -9,11 +10,12 @@ namespace bloch {
 
     class CppGenerator {
        public:
-        explicit CppGenerator(const std::unordered_map<const Expression*, int>& m) : m_measure(m) {}
+        explicit CppGenerator(const std::unordered_map<const Expression*, std::vector<int>>& m)
+            : m_measure(m) {}
         std::string generate(Program& program);
 
        private:
-        const std::unordered_map<const Expression*, int>& m_measure;
+        const std::unordered_map<const Expression*, std::vector<int>>& m_measure;
         int m_indent = 0;
         std::string m_code;
         void indent();

--- a/src/bloch/runtime/qasm_simulator.cpp
+++ b/src/bloch/runtime/qasm_simulator.cpp
@@ -12,8 +12,8 @@ namespace bloch {
         int index = m_qubits++;
         std::vector<std::complex<double>> newState(m_state.size() * 2);
         for (size_t i = 0; i < m_state.size(); ++i) {
-            newState[2 * i] = m_state[i];
-            newState[2 * i + 1] = 0;
+            newState[i] = m_state[i];
+            newState[i + m_state.size()] = 0;
         }
         m_state.swap(newState);
         return index;

--- a/src/bloch/runtime/runtime_evaluator.hpp
+++ b/src/bloch/runtime/runtime_evaluator.hpp
@@ -22,7 +22,7 @@ namespace bloch {
     class RuntimeEvaluator {
        public:
         void execute(Program& program);
-        const std::unordered_map<const Expression*, int>& measurements() const {
+        const std::unordered_map<const Expression*, std::vector<int>>& measurements() const {
             return m_measurements;
         }
         std::string getQasm() const { return m_sim.getQasm(); }
@@ -33,7 +33,7 @@ namespace bloch {
         std::vector<std::unordered_map<std::string, Value>> m_env;
         Value m_returnValue;
         bool m_hasReturn = false;
-        std::unordered_map<const Expression*, int> m_measurements;
+        std::unordered_map<const Expression*, std::vector<int>> m_measurements;
         struct QubitInfo {
             std::string name;
             bool measured;

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -79,4 +79,5 @@ function main() -> void {
 }
 )";
     std::string output = runBloch(src, "coin_flip_test.bloch");
-    EXPECT_EQ("10\n", output);}
+    EXPECT_EQ("10\n", output);
+}

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -56,3 +56,27 @@ function main() -> void {
     std::string output = runBloch(src, "classical_test.bloch");
     EXPECT_EQ("5\n", output);
 }
+
+TEST(IntegrationTest, CountsHeadsInLoop) {
+    std::string src = R"(
+@quantum
+function flip() -> bit {
+    qubit q;
+    x(q);
+    bit r = measure q;
+    return r;
+}
+
+function main() -> void {
+    int heads = 0;
+    for (int i = 0; i < 10; i = i + 1) {
+        bit b = flip();
+        if (b == 1) {
+            heads = heads + 1;
+        }
+    }
+    echo(heads);
+}
+)";
+    std::string output = runBloch(src, "coin_flip_test.bloch");
+    EXPECT_EQ("10\n", output);}

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -46,7 +46,6 @@ TEST(RuntimeTest, CppGenerationOmitsQuantumOps) {
     EXPECT_NE(cpp.find("bool b"), std::string::npos);
 }
 
-
 TEST(RuntimeTest, MeasurementsPreservedInLoops) {
     const char* src =
         "@quantum function flip() -> bit { qubit q; x(q); bit r = measure q; return r; } "

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -45,3 +45,20 @@ TEST(RuntimeTest, CppGenerationOmitsQuantumOps) {
     EXPECT_EQ(cpp.find("measure"), std::string::npos);
     EXPECT_NE(cpp.find("bool b"), std::string::npos);
 }
+
+
+TEST(RuntimeTest, MeasurementsPreservedInLoops) {
+    const char* src =
+        "@quantum function flip() -> bit { qubit q; x(q); bit r = measure q; return r; } "
+        "function main() -> void { for (int i = 0; i < 3; i = i + 1) { bit b = flip(); } }";
+    auto program = parseProgram(src);
+    SemanticAnalyser analyser;
+    analyser.analyse(*program);
+    RuntimeEvaluator eval;
+    eval.execute(*program);
+    const auto& meas = eval.measurements();
+    ASSERT_EQ(meas.size(), 2u);
+    for (const auto& kv : meas) {
+        ASSERT_EQ(kv.second.size(), 3u);
+    }
+}


### PR DESCRIPTION
Measurement results are now stored in a `vector` and so a looped measurement of the same qubit will not overwrite previous measurements

closes #78 